### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ indent_size = 4
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.github/scripts/create-release
+++ b/.github/scripts/create-release
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+set -E
+set -u
+set -o pipefail
+
+declare -r ref="${GITHUB_REF#refs/heads/}"
+declare -r log="docs/changelogs/${ref}.md"
+declare -r title="$(head -n 1 "${log}")"
+
+gh release create "${ref}" \
+  --title "${title### }" \
+  --notes "$(tail -n +3 "${log}")"

--- a/.github/scripts/go-build
+++ b/.github/scripts/go-build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -E
+set -u
+set -o pipefail
+
+declare -r ref="${GITHUB_REF#refs/heads/}"
+declare ext=""
+
+if [[ $GOOS == "windows" ]]
+then
+	ext=".exe"
+fi
+
+go build
+tar --verbose --create --xz --file "templatefile-${ref}-${GOOS}-${GOARCH}.tar.xz" "templatefile${ext}"

--- a/.github/scripts/install-go
+++ b/.github/scripts/install-go
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+set -E
+set -u
+set -o pipefail
+
+declare -r version="go1.16beta1.linux-amd64"
+
+cd "$(mktemp -d)"
+curl --silent --show-error --location --remote-name "https://golang.org/dl/${version}.tar.gz"
+tar --extract --gunzip --file "${version}.tar.gz"
+
+cd 'go'
+printf '%s\n' "GOROOT=${PWD}" >> $GITHUB_ENV
+printf '%s\n' "${PWD}/bin" >> $GITHUB_PATH
+
+"${PWD}/bin/go" version

--- a/.github/scripts/upload-artifacts
+++ b/.github/scripts/upload-artifacts
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+set -E
+set -u
+set -o pipefail
+
+declare -r ref="${GITHUB_REF#refs/heads/}"
+declare -r -x XZ_OP="-9"
+
+gh release upload --clobber "${ref}" "templatefile-${ref}-${GOOS}-${GOARCH}.tar.xz"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,3 +43,11 @@ jobs:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  no-more-jobs:
+    name: No more jobs
+    runs-on: ubuntu-20.04
+    needs:
+      - build
+    steps:
+      - name: 😴
+        run: printf '%s\n' 'No more jobs!'

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,45 @@
+name: Build & release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create Release
+        run: .github/scripts/create-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    name: Build & upload
+    runs-on: ubuntu-20.04
+    needs:
+      - release
+    strategy:
+      max-parallel: 42
+      matrix:
+        include:
+          - GOOS: darwin
+            GOARCH: arm64
+          - GOOS: linux
+            GOARCH: amd64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Go
+        run: .github/scripts/install-go
+      - name: go build ${{ matrix.GOOS }}/${{ matrix.GOARCH }}
+        run: .github/scripts/go-build
+        env:
+          GOOS: ${{ matrix.GOOS }}
+          GOARCH: ${{ matrix.GOARCH }}
+      - name: Upload build artifact
+        run: .github/scripts/upload-artifacts
+        env:
+          GOOS: ${{ matrix.GOOS }}
+          GOARCH: ${{ matrix.GOARCH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+on:
+  push:
+    branches-ignore:
+      - main
+jobs:
+  fmt:
+    name: go fmt
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Go
+        run: .github/scripts/install-go
+      - name: Check *.go
+        run: |
+          test -z "$(go fmt)"
+  tests:
+    name: Tests
+    runs-on: ubuntu-20.04
+    needs:
+      - fmt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Go
+        run: .github/scripts/install-go
+      - name: Run tests
+        run: |
+          go test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,11 @@ jobs:
       - name: go test
         run: |
           go test
+  no-more-jobs:
+    name: No more jobs
+    runs-on: ubuntu-20.04
+    needs:
+      - fmt-test
+    steps:
+      - name: 😴
+        run: printf '%s\n' 'No more jobs!'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,17 @@ on:
     branches-ignore:
       - main
 jobs:
-  fmt:
-    name: go fmt
+  fmt-test:
+    name: fmt and test
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up Go
         run: .github/scripts/install-go
-      - name: Check *.go
+      - name: go fmt
         run: |
           test -z "$(go fmt)"
-  tests:
-    name: Tests
-    runs-on: ubuntu-20.04
-    needs:
-      - fmt
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Set up Go
-        run: .github/scripts/install-go
-      - name: Run tests
+      - name: go test
         run: |
           go test

--- a/docs/changelogs/example.md
+++ b/docs/changelogs/example.md
@@ -1,0 +1,6 @@
+# Example Release Notes
+
+This is a file with example release notes.
+
+The first line of this file becomes the title of the Release
+and lines 3 through EOF are the body.


### PR DESCRIPTION
This PR adds CI workflows for tests and building releases.

Summary of the `test` workflow:

- On each push to the main branch:
    1. Run `go fmt` and check that files are formatted correctly
    2. Run `go test`

Summary of the `build-and-release` workflow:

- On each tag matching `v*` (e.g. `v1.0.0`):
    1. Create a GitHub Release for the tag
        - Pulls the title and body from `docs/changelogs/v1.0.0.md`, so that file must exist
    2. Build a binary for all the supported platforms
    3. Attach the binary to the Release
