### PR TITLE
Run Zizmor against all workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,12 @@ updates:
     schedule:
       interval: "daily"
     labels: [ ]
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 3
+      default-days: 7
     labels: [ ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,6 +21,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          cache: false
           go-version-file: go.mod
       - name: go build darwin/arm64
         run: .github/scripts/go-build

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write     # Required by `gh release create` & read to clone the repo
-      id-token: write     # Required to mint a Sigstore OIDC token (actions/attest-build-provenance)
-      attestations: write # Required to upload the signed attestation (actions/attest-build-provenance)
+      id-token: write     # Required to mint a Sigstore OIDC token (actions/attest)
+      attestations: write # Required to upload the signed attestation (actions/attest)
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -42,7 +42,7 @@ jobs:
           GOOS: linux
           GOARCH: amd64
       - name: Generate signed build provenance attestations
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: 'templatefile-${{ github.ref_name }}-*.tar.xz'
       - name: Create release

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,17 +3,20 @@ on:
   push:
     tags:
       - 'v*'
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
     name: Build, attest & release
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: write     # Required by `gh release create` & read to clone the repo
+      id-token: write     # Required to mint a Sigstore OIDC token (actions/attest-build-provenance)
+      attestations: write # Required to upload the signed attestation (actions/attest-build-provenance)
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,6 +48,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,17 +20,20 @@ on:
   schedule:
     - cron: '33 9 * * 1'
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
     permissions:
-      security-events: write
-      actions: read
-      contents: read
+      contents: read         # Required to clone the repo
+      actions: read          # Required to read workflow metadata
+      security-events: write # Required to publish SARIF results to code scanning (codeql-action/upload-sarif)
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,5 +22,7 @@ jobs:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,12 +9,18 @@
 name: Dependency Review
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependency-review:
+    name: Dependency review
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to clone the repo and call the dependency review APIs
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -6,22 +6,24 @@ on:
   push:
     branches: ["main"]
 
-# Declare default permissions as read only
-permissions: read-all
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-24.04
     permissions:
-      # Needed to upload the results to code-scanning dashboard
-      security-events: write
-      id-token: write
-      contents: read
-      actions: read
-      issues: read
-      pull-requests: read
-      checks: read
+      contents: read         # Required to clone the repo
+      security-events: write # Required to publish SARIF results to code scanning (codeql-action/upload-sarif)
+      id-token: write        # Required for OIDC verification when publishing (ossf/scorecard-action)
+      actions: read          # Required to read workflow metadata (ossf/scorecard-action)
+      issues: read           # Required for issue queries (ossf/scorecard-action)
+      pull-requests: read    # Required for the Branch-Protection check (ossf/scorecard-action)
+      checks: read           # Required for SAST detection checks (ossf/scorecard-action)
 
     steps:
       - name: Harden the runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -34,6 +36,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -51,6 +55,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,18 @@ on:
   push:
     branches-ignore:
       - main
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to clone the repo
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -29,6 +34,8 @@ jobs:
   pinact-verify:
     name: Verify GitHub Actions versions
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to clone the repo
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -48,6 +55,8 @@ jobs:
   fmt-test:
     name: fmt and test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to clone the repo
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,13 +8,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: Run zizmor analysis
     runs-on: ubuntu-24.04
     permissions:
-      # Required to upload SARIF files
-      security-events: write
+      contents: read         # Required to clone the repo
+      security-events: write # Required to publish SARIF results to code scanning
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      # Required to upload SARIF files
+      security-events: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: true
+          persona: pedantic


### PR DESCRIPTION
This PR adds a job to run [`zizmor`](https://docs.zizmor.sh) against all of the GitHub Actions workflows.

It surfaced a good handful of issues! So I fixed those up as well.